### PR TITLE
[OND211-2418] fix(keycloak): key the shared provider registry by credentials, not id(config)

### DIFF
--- a/ondewo/sip/utils/keycloak.py
+++ b/ondewo/sip/utils/keycloak.py
@@ -33,6 +33,7 @@ No 2FA is involved: the account is a 2FA-exempt technical user and ROPC bypasses
 browser flow (D14). The client is public, so no ``client_secret`` is sent.
 """
 
+import hashlib
 import threading
 import time
 import weakref
@@ -525,11 +526,49 @@ class KeycloakTokenProvider:
         self._access_token_expires_at = self._time_fn() + expires_in
 
 
-# One shared provider per ClientConfig so the ROPC offline-token login happens once for all
-# of a client's service stubs (they all read the same auto-refreshed access token). The weak
-# reference lets the provider be collected once the config is gone.
-_PROVIDER_REGISTRY: "WeakValueDictionary[int, KeycloakTokenProvider]" = WeakValueDictionary()
+# One shared provider per set of Keycloak credentials so the ROPC offline-token login happens
+# once for all of a client's service stubs (they all read the same auto-refreshed access token).
+# The weak reference lets the provider be collected once the last stub holding it is gone.
+#
+# The key MUST be derived from the credentials, never from `id(config)`. The service interfaces keep
+# only the grpc channel, so the `ClientConfig` in the usual `Client(config=ClientConfig(...))` call is
+# unreachable the moment the client is built; CPython then reuses its address for the next
+# `ClientConfig`, and a registry keyed by that stale int handed the new client the PREVIOUS user's
+# still-alive provider. The second client then silently authenticated as the first user — including
+# with credentials that do not exist at all.
+_PROVIDER_REGISTRY: "WeakValueDictionary[str, KeycloakTokenProvider]" = WeakValueDictionary()
 _PROVIDER_REGISTRY_LOCK: threading.Lock = threading.Lock()
+
+
+def _provider_registry_key(config: ClientConfig) -> str:
+    """
+    Derive the registry key identifying the Keycloak identity a config authenticates as.
+
+    Every field the provider is constructed from takes part, so two configs share a provider
+    exactly when a shared provider would behave identically for both. The fields are hashed
+    rather than stored verbatim because one of them is the password: a plain tuple key would put
+    the secret in a module-level dict and in the locals of this frame, where any traceback
+    renderer that shows locals would print it.
+
+    Args:
+        config (ClientConfig):
+            A config with the Keycloak headless-auth fields set.
+
+    Returns:
+        str:
+            A hex digest identifying the credential set.
+    """
+    fields: List[str] = [
+        config.keycloak_url,
+        config.realm,
+        config.client_id,
+        config.user_name,
+        config.password,
+        "" if config.token_expiration_in_s is None else str(config.token_expiration_in_s),
+        str(config.keycloak_verify_ssl),
+    ]
+    # '\0' cannot occur in any of the fields, so the join is unambiguous.
+    return hashlib.sha256("\0".join(fields).encode("utf-8")).hexdigest()
 
 
 def get_keycloak_token_provider(config: ClientConfig) -> KeycloakTokenProvider:
@@ -548,7 +587,7 @@ def get_keycloak_token_provider(config: ClientConfig) -> KeycloakTokenProvider:
         KeycloakTokenProvider:
             The provider bound to this config (created on first call).
     """
-    key: int = id(config)
+    key: str = _provider_registry_key(config)
     with _PROVIDER_REGISTRY_LOCK:
         provider: Optional[KeycloakTokenProvider] = _PROVIDER_REGISTRY.get(key)
         if provider is None:

--- a/tests/unit/utils/test_keycloak.py
+++ b/tests/unit/utils/test_keycloak.py
@@ -501,6 +501,127 @@ class TestSharedProviderRegistry:
 
         assert provider.token_expiration_in_s == token_expiration_in_s
 
+    def test_configs_with_equal_credentials_share_one_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Two SIMULTANEOUSLY-ALIVE, credential-identical configs must resolve to one provider.
+
+        Both configs are kept referenced on purpose: that is what makes this deterministic. Under the
+        old `id(config)` keying two live configs always have different addresses, so this produced two
+        providers and two ROPC logins. Identity-based keying is also what made a cross-identity leak
+        possible -- an address is reused as soon as its config is collected, and the service interfaces
+        keep only the grpc channel, so the config of `Client(config=ClientConfig(...))` dies the moment
+        the client is built.
+
+        Args:
+            monkeypatch (pytest.MonkeyPatch):
+                Fixture used to patch `requests.post` so the default transport hits no network.
+        """
+        post_calls: List[Dict[str, str]] = []
+
+        def fake_post(url: str, data: Dict[str, str], timeout: float, verify: bool = True) -> FakeResponse:
+            """Record the POST and return a canned successful login response.
+
+            Args:
+                url (str):
+                    The token-endpoint URL.
+                data (Dict[str, str]):
+                    The form-encoded request parameters.
+                timeout (float):
+                    The request timeout (unused).
+                verify (bool):
+                    Whether TLS verification is on (unused).
+
+            Returns:
+                FakeResponse:
+                    A 200 response carrying access/refresh tokens.
+            """
+            post_calls.append({"url": url, **data})
+            return FakeResponse(200, _token_body("acc-1", "off-1", 300))
+
+        monkeypatch.setattr(keycloak_module.requests, "post", fake_post)
+
+        def build_config() -> ClientConfig:
+            """Build a config carrying the shared test credentials."""
+            return ClientConfig(
+                host="localhost",
+                port="50055",
+                user_name=USERNAME,
+                password=PASSWORD,
+                keycloak_url=KEYCLOAK_URL,
+                realm=REALM,
+                client_id=CLIENT_ID,
+            )
+
+        first_config: ClientConfig = build_config()
+        second_config: ClientConfig = build_config()
+        assert first_config is not second_config
+
+        first: KeycloakTokenProvider = get_keycloak_token_provider(first_config)
+        second: KeycloakTokenProvider = get_keycloak_token_provider(second_config)
+
+        assert first is second
+        # One ROPC login for both configs, which is the whole point of the shared registry.
+        assert len(post_calls) == 1
+
+    def test_configs_with_different_credentials_never_share_a_provider(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Differing credentials must never resolve to the same provider.
+
+        This is the security half of the keying contract: a client must authenticate as the identity
+        its own config names, never as one an earlier client happened to register.
+
+        Args:
+            monkeypatch (pytest.MonkeyPatch):
+                Fixture used to patch `requests.post` so the default transport hits no network.
+        """
+        logged_in_as: List[str] = []
+
+        def fake_post(url: str, data: Dict[str, str], timeout: float, verify: bool = True) -> FakeResponse:
+            """Record the username each login used and return a canned response.
+
+            Args:
+                url (str):
+                    The token-endpoint URL (unused).
+                data (Dict[str, str]):
+                    The form-encoded request parameters.
+                timeout (float):
+                    The request timeout (unused).
+                verify (bool):
+                    Whether TLS verification is on (unused).
+
+            Returns:
+                FakeResponse:
+                    A 200 response carrying access/refresh tokens.
+            """
+            logged_in_as.append(data["username"])
+            return FakeResponse(200, _token_body("acc-1", "off-1", 300))
+
+        monkeypatch.setattr(keycloak_module.requests, "post", fake_post)
+
+        other_username: str = "someone-else@example.com"
+
+        def build_config(user_name: str) -> ClientConfig:
+            """Build a config for the given identity."""
+            return ClientConfig(
+                host="localhost",
+                port="50055",
+                user_name=user_name,
+                password=PASSWORD,
+                keycloak_url=KEYCLOAK_URL,
+                realm=REALM,
+                client_id=CLIENT_ID,
+            )
+
+        first: KeycloakTokenProvider = get_keycloak_token_provider(build_config(USERNAME))
+        second: KeycloakTokenProvider = get_keycloak_token_provider(build_config(other_username))
+
+        assert first is not second
+        assert first.username == USERNAME
+        assert second.username == other_username
+        # Each identity logged in with its OWN credentials; neither rode on the other's token.
+        assert logged_in_as == [USERNAME, other_username]
+
 
 class TestDefaultRequestsTransport:
     """The default `_RequestsTransport` used when no transport is injected (production path)."""


### PR DESCRIPTION
## The bug

`_PROVIDER_REGISTRY` was keyed by `id(config)`. The service interfaces keep only the grpc
channel, so the `ClientConfig` in the usual `Client(config=ClientConfig(...))` call is
unreachable the moment the client is built. CPython then reuses that address for the next
`ClientConfig`, and the registry handed the new client the **previous user's** still-alive
provider — so the second client silently authenticated as the first user, including with
credentials that do not exist at all. No exception, no warning.

## The fix

Key on a sha256 over every field the provider is constructed from, so two configs share a
provider exactly when a shared provider would behave identically for both. The fields are
hashed rather than stored verbatim because one of them is the password: a plain tuple key
would put the secret in a module-level dict and in that frame's locals, where any traceback
renderer showing locals would print it.

## Verification

Both halves of the keying contract are covered:

- credential-identical configs that are **simultaneously alive** resolve to one provider and
  one ROPC login;
- configs with differing credentials never share one — each logs in as itself.

Confirmed the regression test bites: restoring `key = id(config)` fails
`test_configs_with_equal_credentials_share_one_provider`, and the fix makes it pass.
`ruff check`, `ruff format`, `mypy` and all 39 unit tests are green.